### PR TITLE
Websocket support

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -30,8 +30,9 @@ http {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
-      proxy_read_timeout 86400s
-      proxy_send_timeout 86400s
+      proxy_read_timeout 1d;
+      proxy_send_timeout 1d;
+      websocket_connect_timeout 1d;
     }
   }
 }       

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -25,6 +25,13 @@ http {
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
+
+      # enables WS support
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+      proxy_read_timeout 86400s
+      proxy_send_timeout 86400s
     }
   }
 }       

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -32,7 +32,6 @@ http {
       proxy_set_header Connection "upgrade";
       proxy_read_timeout 1d;
       proxy_send_timeout 1d;
-      websocket_connect_timeout 1d;
     }
   }
 }       


### PR DESCRIPTION
Hi!

I also need websocket support in the proxy and found the pull request from @Vad1mo.

I've updated time values to 1d, added missing semicolons (I've got errors during docker build without them).

I skipped option "websocket_connect_timeout", it  seems to be invalid:

nginx: [emerg] unknown directive "websocket_connect_timeout" in /etc/nginx/nginx.conf:35