### PR TITLE
Create certificate with TLS Web Server Authentication in the X509 extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11
+FROM alpine:3.14
 
 LABEL maintainer="esplo <esplo@users.noreply.github.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
-FROM alpine:3.6
+FROM alpine:3.11
 
 LABEL maintainer="esplo <esplo@users.noreply.github.com>"
 
 ENV NGINX_VERSION 1.13.5
 
-RUN apk add --no-cache openssl nginx gettext \
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache openssl nginx gettext \
     && mkdir -p /etc/nginx/ssl/ \
-    && openssl req -new -x509 -sha256 -newkey rsa:2048 -days 365 -nodes -out /etc/nginx/ssl/nginx.pem -keyout /etc/nginx/ssl/nginx.key -subj "/C=JP/ST=MyState/L=MyLocality/O=MyOrg/OU=dev/CN=localhost" \
     && mkdir -p /run/nginx/
+
+RUN openssl req -new \
+    -x509 \
+    -sha256 \
+    -newkey rsa:2048 \
+    -days 365 \
+    -nodes \
+    -out /etc/nginx/ssl/nginx.pem \
+    -keyout /etc/nginx/ssl/nginx.key \
+    -subj "/C=JP/ST=MyState/L=MyLocality/O=MyOrg/OU=dev/CN=localhost" \
+    -addext "subjectAltName = DNS:8.8.8.8,IP:127.0.0.1,IP:192.168.1.1" \
+    -addext "extendedKeyUsage = serverAuth"
 
 COPY nginx.conf.template /etc/nginx/nginx.conf.template
 COPY entrypoint.sh .


### PR DESCRIPTION
I'm not the best at certificates, but on Stack Overflow post linked in the README there was a way to easier bypass chrome's guard.

All is needed is to add to `openssl` command:

```sh
-addext "subjectAltName = DNS:8.8.8.8,IP:127.0.0.1,IP:192.168.1.1"
-addext "extendedKeyUsage = serverAuth"
```

It also required to upgrade `openssl` and thus version of `alpine`.