### PR TITLE
Version updates and minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.15
 
 LABEL maintainer="esplo <esplo@users.noreply.github.com>"
 
-ENV NGINX_VERSION 1.13.5
+ENV NGINX_VERSION 1.20.2
 
 RUN apk update \
     && apk upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.15
 
 LABEL maintainer="esplo <esplo@users.noreply.github.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY nginx.conf.template /etc/nginx/nginx.conf.template
 COPY entrypoint.sh .
 
 EXPOSE 443
-STOPSIGNAL SIGTERM
+
+STOPSIGNAL SIGQUIT
 
 ENTRYPOINT sh entrypoint.sh

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -16,12 +16,11 @@ http {
     listen 443 ssl;
     server_name localhost;
 
-    ssl on;
     ssl_certificate         /etc/nginx/ssl/nginx.pem;
     ssl_certificate_key     /etc/nginx/ssl/nginx.key;
     location / {
       proxy_pass              http://app;
-      proxy_set_header        Host    $host;
+      proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;


### PR DESCRIPTION
- Updated to latest stable Alpine (3.15)
- Updated nginx to latest stable (1.20.2)
- Switched from SIGTERM to SIGQUIT (see https://github.com/nginxinc/docker-nginx/issues/377)
- Removed deprecated ssl directive from nginx config