### PR TITLE
Adds linux/arm64 docker build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -26,5 +26,6 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: esplo/docker-local-ssl-termination-proxy:latest


### PR DESCRIPTION
This adds `linux/arm64` platform to the docker build so the image should be run natively on a Macbook M1 (and other arm64 platforms).