### PR TITLE
Add SSL_CERT and SSL_KEY env vars for locally-trusted SSL certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ LABEL maintainer="esplo <esplo@users.noreply.github.com>"
 
 ENV NGINX_VERSION 1.13.5
 
+ENV PORT=443
+ENV SSL_CERT=nginx.pem
+ENV SSL_KEY=nginx.key
+
 RUN apk update \
     && apk upgrade \
     && apk add --no-cache openssl nginx gettext \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ You need to make sure that `host.docker.internal` is resolved properly inside do
 $ curl -k https://localhost/
 ```
 
+### Locally-trusted development certificates
+
+The container can be configured to use custom certificates with the `SSL_CERT` and `SSL_KEY` environment variables. You can use [mkcert](https://github.com/FiloSottile/mkcert) to generate locally-trusted development certificates:
+
+```bash
+$ mkdir -p ssl
+$ mkcert -install
+$ mkcert --cert-file ssl/localhost.pem --key-file ssl/localhost.key localhost 127.0.0.1 ::1
+```
+
+and mount them to the container using [bind mounts](https://docs.docker.com/storage/bind-mounts/):
+
+```bash
+$ docker run -it \
+  -e 'PORT=8000' \
+  -e 'SSL_CERT=localhost.pem' \
+  -e 'SSL_KEY=localhost.key' \
+  -p 443:443 \
+  -v "$(pwd)"/ssl:/etc/nginx/ssl/ \
+  --rm \
+  esplo/docker-local-ssl-termination-proxy
+```
+
 ## Troubleshoot
 
 ### "Your connection is not private" in Chrome

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-envsubst '$$PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
+envsubst '$$PORT $$SSL_CERT $$SSL_KEY' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 cat /etc/nginx/nginx.conf
 nginx

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -17,8 +17,8 @@ http {
     server_name localhost;
 
     ssl on;
-    ssl_certificate         /etc/nginx/ssl/nginx.pem;
-    ssl_certificate_key     /etc/nginx/ssl/nginx.key;
+    ssl_certificate         /etc/nginx/ssl/${SSL_CERT};
+    ssl_certificate_key     /etc/nginx/ssl/${SSL_KEY};
     location / {
       proxy_pass              http://app;
       proxy_set_header        Host    $host;


### PR DESCRIPTION
This adds the ability to use locally-trusted, custom SSL certificates instead of the default ones provided by the container.