### PR TITLE
Disable proxy buffering to avoid 502 bad gateway errors

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -26,6 +26,11 @@ http {
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
 
+      proxy_buffering off;
+      proxy_buffer_size 16k;
+      proxy_busy_buffers_size 24k;
+      proxy_buffers 64 4k;
+
       # enables WS support
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
When proxying requests to a local nginx server, I run into 502 bad gateway errors. Adjusting the buffer settings according to [this blog](https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx) helps.